### PR TITLE
fix-step-8-creating-network-topology-graph

### DIFF
--- a/core/opengraph_builder.py
+++ b/core/opengraph_builder.py
@@ -156,10 +156,10 @@ class NetworkTopologyBuilder:
                 "ssl_validity_period_days": ssl_cert.get('validity_period_days'),
                 
                 # Subject Alternative Names (enhanced)
-                "ssl_subject_alt_names": ssl_cert.get('subject_alt_names', []),
-                "ssl_san_dns_names": ssl_cert.get('san_dns_names', []),
-                "ssl_san_ip_addresses": ssl_cert.get('san_ip_addresses', []),
-                "ssl_san_email_addresses": ssl_cert.get('san_email_addresses', []),
+                "ssl_subject_alt_names": [str(i) for i in (ssl_cert.get('subject_alt_names') or []) if i is not None],
+                "ssl_san_dns_names": [str(i) for i in (ssl_cert.get('san_dns_names') or []) if i is not None],
+                "ssl_san_ip_addresses": [str(i) for i in (ssl_cert.get('san_ip_addresses') or []) if i is not None],
+                "ssl_san_email_addresses": [str(i) for i in (ssl_cert.get('san_email_addresses') or []) if i is not None],
                 
                 # Certificate chain
                 "ssl_certificate_chain_length": ssl_cert.get('certificate_chain_length', 1),


### PR DESCRIPTION
Parsed SAN attributes retrieved from certificate objects expect only strings and fails to properly build the graph at Step 8. Changed to add dictionary or None values as well. Addressing open issue currently. This was tested with success